### PR TITLE
change default csi template path

### DIFF
--- a/cluster/examples/kubernetes/ceph/operator-with-csi.yaml
+++ b/cluster/examples/kubernetes/ceph/operator-with-csi.yaml
@@ -69,6 +69,15 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        # Path to the CSI templates
+        - name: ROOK_CSI_RBD_PLUGIN_TEMPLATE_PATH
+          value: /usr/share/k8s-yaml/rook/ceph/csi/template/csi-rbdplugin.yaml
+        - name: ROOK_CSI_RBD_PROVISIONER_TEMPLATE_PATH
+          value: /usr/share/k8s-yaml/rook/ceph/csi/template/csi-rbdplugin-provisioner.yaml
+        - name: ROOK_CSI_CEPHFS_PLUGIN_TEMPLATE_PATH
+          value: /usr/share/k8s-yaml/rook/ceph/csi/template/csi-cephfsplugin.yaml
+        - name: ROOK_CSI_CEPHFS_PROVISIONER_TEMPLATE_PATH
+          value: /usr/share/k8s-yaml/rook/ceph/csi/template/csi-cephfsplugin-provisioner.yaml
       volumes:
       - name: rook-config
         emptyDir: {}


### PR DESCRIPTION
Default path to the csi template is set as "/etc/ceph-csi" which is not right as those aren't configuration files and shouldn't change.
Change it to the path were all manifests for the package are stored.