### PR TITLE
Granting necessary priviledges for CSI-services

### DIFF
--- a/cluster/examples/kubernetes/ceph/cluster.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster.yaml
@@ -27,7 +27,7 @@ spec:
   # The path on the host where configuration files will be persisted. Must be specified.
   # Important: if you reinstall the cluster, make sure you delete this directory from each host or else the mons will fail to start on the new cluster.
   # In Minikube, the '/data' directory is configured to persist across reboots. Use "/data/rook" in Minikube environment.
-  dataDirHostPath: /var/lib/rook
+  dataDirHostPath: /home/ses/var/lib/rook
   # set the amount of mons to be started
   mon:
     count: 3

--- a/cluster/examples/kubernetes/ceph/operator-with-csi.yaml
+++ b/cluster/examples/kubernetes/ceph/operator-with-csi.yaml
@@ -67,6 +67,15 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        # Path to the CSI templates
+        - name: ROOK_CSI_RBD_PLUGIN_TEMPLATE_PATH
+          value: /usr/share/k8s-yaml/rook/ceph/csi/template/rbd/csi-rbdplugin.yaml
+        - name: ROOK_CSI_RBD_PROVISIONER_TEMPLATE_PATH
+          value: /usr/share/k8s-yaml/rook/ceph/csi/template/rbd/csi-rbdplugin-provisioner.yaml
+        - name: ROOK_CSI_CEPHFS_PLUGIN_TEMPLATE_PATH
+          value: /usr/share/k8s-yaml/rook/ceph/csi/template/cephfs/csi-cephfsplugin.yaml
+        - name: ROOK_CSI_CEPHFS_PROVISIONER_TEMPLATE_PATH
+          value: /usr/share/k8s-yaml/rook/ceph/csi/template/cephfs/csi-cephfsplugin-provisioner.yaml
       volumes:
       - name: rook-config
         emptyDir: {}

--- a/cluster/examples/kubernetes/ceph/operator-with-csi.yaml
+++ b/cluster/examples/kubernetes/ceph/operator-with-csi.yaml
@@ -52,6 +52,8 @@ spec:
           value: "quay.io/k8scsi/csi-snapshotter:v1.1.0"
         - name: ROOK_CSI_ATTACHER_IMAGE
           value: "quay.io/k8scsi/csi-attacher:v1.1.1"
+        - name: FLEXVOLUME_DIR_PATH
+          value: "/var/lib/kubelet/plugins/volume/exec"
         # The name of the node to pass with the downward API
         - name: NODE_NAME
           valueFrom:

--- a/cluster/examples/kubernetes/ceph/psp.yaml
+++ b/cluster/examples/kubernetes/ceph/psp.yaml
@@ -1,15 +1,21 @@
-apiVersion: extensions/v1beta1
+---
+
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: rook
+  name: rook-privileged
 spec:
+  # TODO: can fsGroup be trimmed down?
   fsGroup:
     rule: RunAsAny
   privileged: true
+  # TODO: can runAsUser be trimmed down?
   runAsUser:
     rule: RunAsAny
+  # TODO: can seLinux be trimmed down?
   seLinux:
     rule: RunAsAny
+  # TODO: can supplementalGroups be trimmed down?
   supplementalGroups:
     rule: RunAsAny
   volumes:
@@ -18,19 +24,101 @@ spec:
     - 'projected'
     - 'secret'
     - 'downwardAPI'
+    # - 'persistentVolumeClaim'
     - 'hostPath'
     - 'flexVolume'
+    # allowedHostPaths:
+    #   - /var/lib/rook
+    #   - /dev
+    #   - ???others???
+  # allowedCapabilities:
+  #   - '*'
   hostPID: true
+  # hostIPC: true
   hostNetwork: true
-  hostIPC: true
-  # The following section is only needed when hostNetwork: true
   hostPorts:
-    # Ceph msgr2 port
-    - min: 3300
-      max: 3300
-    # Ceph msgr1 ports
-    - min: 6789
-      max: 7300
-    # Ceph MGR Prometheus Metrics
-    - min: 9283
-      max: 9283
+    - min: 1
+      max: 65535
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: 'psp:rook'
+rules:
+  - apiGroups:
+      - policy
+    resources:
+      - podsecuritypolicies
+    resourceNames:
+      - rook-privileged
+    verbs:
+      - use
+
+---
+
+# Allow the rook-ceph-system serviceAccount to use the privileged PSP
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rook-ceph-system-psp
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: 'psp:rook'
+subjects:
+  - kind: ServiceAccount
+    name: rook-ceph-system
+    namespace: rook-ceph
+
+---
+
+# Allow the default serviceAccount to use the privileged PSP
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: rook-ceph-default-psp
+  namespace: rook-ceph
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: psp:rook
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: rook-ceph
+
+---
+
+# Allow the rook-ceph-osd serviceAccount to use the privileged PSP
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: rook-ceph-osd-psp
+  namespace: rook-ceph
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: psp:rook
+subjects:
+- kind: ServiceAccount
+  name: rook-ceph-osd
+  namespace: rook-ceph
+
+---
+
+# Allow the rook-ceph-mgr serviceAccount to use the privileged PSP
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: rook-ceph-mgr-psp
+  namespace: rook-ceph
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: psp:rook
+subjects:
+- kind: ServiceAccount
+  name: rook-ceph-mgr
+  namespace: rook-ceph

--- a/cluster/examples/kubernetes/ceph/psp.yaml
+++ b/cluster/examples/kubernetes/ceph/psp.yaml
@@ -74,6 +74,70 @@ subjects:
 
 ---
 
+# Allow the rook-csi-cephfs-plugin-sa serviceAccount to use the privileged PSP
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rook-csi-cephfs-plugin-sa-psp
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: psp:rook
+subjects:
+- kind: ServiceAccount
+  name: rook-csi-cephfs-plugin-sa
+  namespace: rook-ceph
+
+---
+
+# Allow the rook-csi-cephfs-provisioner-sa serviceAccount to use the privileged PSP
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rook-csi-cephfs-provisioner-sa-psp
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: psp:rook
+subjects:
+- kind: ServiceAccount
+  name: rook-csi-cephfs-provisioner-sa
+  namespace: rook-ceph
+
+---
+
+# Allow the rook-csi-rbd-plugin-sa serviceAccount to use the privileged PSP
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rook-csi-rbd-plugin-sa-psp
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: psp:rook
+subjects:
+- kind: ServiceAccount
+  name: rook-csi-rbd-plugin-sa
+  namespace: rook-ceph
+
+---
+
+# Allow the rook-csi-rbd-provisioner-sa serviceAccount to use the privileged PSP
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rook-csi-rbd-provisioner-sa-psp
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: psp:rook
+subjects:
+- kind: ServiceAccount
+  name: rook-csi-rbd-provisioner-sa
+  namespace: rook-ceph
+
+---
+
 # Allow the default serviceAccount to use the privileged PSP
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/cluster/examples/kubernetes/ceph/psp.yaml
+++ b/cluster/examples/kubernetes/ceph/psp.yaml
@@ -24,7 +24,7 @@ spec:
     - 'projected'
     - 'secret'
     - 'downwardAPI'
-    # - 'persistentVolumeClaim'
+    - 'persistentVolumeClaim'
     - 'hostPath'
     - 'flexVolume'
     # allowedHostPaths:
@@ -33,9 +33,12 @@ spec:
     #   - ???others???
   # allowedCapabilities:
   #   - '*'
+  allowPrivilegeEscalation: true
   hostPID: true
-  # hostIPC: true
+  hostIPC: true
   hostNetwork: true
+  allowedCapabilities:
+  - '*'
   hostPorts:
     - min: 1
       max: 65535


### PR DESCRIPTION
- Connected all CSI-relevant service accounts to our PodSecurityPolicy
- Added the correct Flexvolume directory which is still necessary for the rook-agent