### PR TITLE
bsc#1152690 - ceph-csi: Driver will fail with error

### DIFF
--- a/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin-provisioner-dep.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin-provisioner-dep.yaml
@@ -65,6 +65,7 @@ spec:
             - "--metricsport=9091"
             - "--metricspath=/metrics"
             - "--enablegrpcmetrics={{ .EnableCSIGRPCMetrics }}"
+            - "--forcecephkernelclient=true"
           env:
             - name: POD_IP
               valueFrom:
@@ -104,6 +105,7 @@ spec:
             - "--metricspath=/metrics"
             - "--polltime=60s"
             - "--timeout=3s"
+            - "--forcecephkernelclient=true"
           env:
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock

--- a/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin-provisioner-sts.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin-provisioner-sts.yaml
@@ -60,6 +60,7 @@ spec:
             - "--metricsport=9091"
             - "--metricspath=/metrics"
             - "--enablegrpcmetrics={{ .EnableCSIGRPCMetrics }}"
+            - "--forcecephkernelclient=true"
           env:
             - name: POD_IP
               valueFrom:
@@ -99,6 +100,7 @@ spec:
             - "--metricspath=/metrics"
             - "--polltime=60s"
             - "--timeout=3s"
+            - "--forcecephkernelclient=true"
           env:
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock

--- a/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin.yaml
@@ -58,6 +58,7 @@ spec:
             - "--metricsport=9091"
             - "--metricspath=/metrics"
             - "--enablegrpcmetrics={{ .EnableCSIGRPCMetrics }}"
+            - "--forcecephkernelclient=true"
           env:
             - name: POD_IP
               valueFrom:
@@ -105,6 +106,7 @@ spec:
             - "--metricspath=/metrics"
             - "--polltime=60s"
             - "--timeout=3s"
+            - "--forcecephkernelclient=true"
           env:
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock

--- a/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin-provisioner-dep.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin-provisioner-dep.yaml
@@ -82,6 +82,7 @@ spec:
             - "--metricsport=9090"
             - "--metricspath=/metrics"
             - "--enablegrpcmetrics={{ .EnableCSIGRPCMetrics }}"
+            - "--forcecephkernelclient=true"
           env:
             - name: POD_IP
               valueFrom:
@@ -125,6 +126,7 @@ spec:
             - "--metricspath=/metrics"
             - "--polltime=60s"
             - "--timeout=3s"
+            - "--forcecephkernelclient=true"
           env:
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock

--- a/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin-provisioner-sts.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin-provisioner-sts.yaml
@@ -75,6 +75,7 @@ spec:
             - "--metricsport=9090"
             - "--metricspath=/metrics"
             - "--enablegrpcmetrics={{ .EnableCSIGRPCMetrics }}"
+            - "--forcecephkernelclient=true"
           env:
             - name: POD_IP
               valueFrom:
@@ -118,6 +119,7 @@ spec:
             - "--metricspath=/metrics"
             - "--polltime=60s"
             - "--timeout=3s"
+            - "--forcecephkernelclient=true"
           env:
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock

--- a/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin.yaml
@@ -58,6 +58,7 @@ spec:
             - "--metricsport=9090"
             - "--metricspath=/metrics"
             - "--enablegrpcmetrics={{ .EnableCSIGRPCMetrics }}"
+            - "--forcecephkernelclient=true"
           env:
             - name: POD_IP
               valueFrom:
@@ -107,6 +108,7 @@ spec:
             - "--metricspath=/metrics"
             - "--polltime=60s"
             - "--timeout=3s"
+            - "--forcecephkernelclient=true"
           env:
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock


### PR DESCRIPTION
Added the new parameter to force the CSI-containers to use the kernel mounter instead of fuse
Signed-off-by: Stefan Haas <shaas@suse.com>
